### PR TITLE
chore: remove unused react-google-recaptcha-v3 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "^19.0.0",
         "react-fast-marquee": "^1.6.5",
         "react-google-recaptcha": "^3.1.0",
-        "react-google-recaptcha-v3": "^1.10.1",
         "react-icons": "^5.4.0",
         "react-type-animation": "^3.2.0",
         "tailwind-merge": "^2.5.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-dom": "^19.0.0",
     "react-fast-marquee": "^1.6.5",
     "react-google-recaptcha": "^3.1.0",
-    "react-google-recaptcha-v3": "^1.10.1",
     "react-icons": "^5.4.0",
     "react-type-animation": "^3.2.0",
     "tailwind-merge": "^2.5.5",


### PR DESCRIPTION
Removes the unused "react-google-recaptcha-v3" dependency from 
package.json and package-lock.json to streamline the project 
and reduce potential security vulnerabilities. This change 
improves the overall dependency management and keeps the 
project clean.