### PR TITLE
Make site-config the real single source of truth

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -27,17 +27,19 @@ export const siteConfig = {
   location: 'Your Country',
   email: 'you@example.com',
   greetings: ['Hello!', 1000, 'Hola!', 1000, 'Bonjour!', 1000],
+  defaultTheme: 'light',
 };
 ```
 
-| Field       | Where it appears                                                             |
-| ----------- | ---------------------------------------------------------------------------- |
-| `name`      | Hero section, footer copyright, SEO metadata, OG image, JSON-LD              |
-| `jobTitle`  | OG image, SEO metadata                                                       |
-| `bio`       | Hero section, LinkedIn preview card                                          |
-| `location`  | JSON-LD schema                                                               |
-| `email`     | Contact page (if used)                                                       |
-| `greetings` | Hero section typing animation (alternates `[text, delay, text, delay, ...]`) |
+| Field          | Where it appears                                                             |
+| -------------- | ---------------------------------------------------------------------------- |
+| `name`         | Hero section, footer copyright, SEO metadata, OG image, JSON-LD              |
+| `jobTitle`     | OG image, SEO metadata                                                       |
+| `bio`          | Hero section, LinkedIn preview card                                          |
+| `location`     | JSON-LD schema                                                               |
+| `email`        | Contact page (if used)                                                       |
+| `greetings`    | Hero section typing animation (alternates `[text, delay, text, delay, ...]`) |
+| `defaultTheme` | Theme on first visit — `'light'`, `'dark'`, or `'system'` (follows the OS)   |
 
 ### URLs & Social Links (`siteUrls`)
 
@@ -100,7 +102,7 @@ export const projects = [
     tech: ['React', 'TypeScript'],
     github: 'https://github.com/you/project',
     live: 'https://project.example.com',
-    image: 'project-screenshot.png', // filename in src/media/
+    image: myProjectImage, // imported at the top of site-config.ts
   },
 ];
 ```
@@ -108,15 +110,13 @@ export const projects = [
 **Adding a new project:**
 
 1. Add the project image to `src/media/`
-2. Add the project entry to the `projects` array in `site-config.ts`
-3. In `src/sections/projects.tsx`, import your image and add it to the `imageMap` object:
+2. Import it at the top of `site-config.ts`:
    ```ts
    import myProjectImage from '../media/my-project.png';
-   const imageMap = {
-     // ...existing entries
-     'my-project.png': myProjectImage,
-   };
    ```
+3. Add the project entry to the `projects` array, referencing the import
+
+Projects appear on the site in array order, so put the one you want featured first.
 
 ### Journey Timeline (`timelineData`)
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,8 +103,8 @@ export default function RootLayout({
       <body className={spaceGrotesk.className}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="light"
-          enableSystem={false}
+          defaultTheme={siteConfig.defaultTheme}
+          enableSystem={siteConfig.defaultTheme === 'system'}
           disableTransitionOnChange
         >
           {children}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
-    <NextThemesProvider {...props} defaultTheme="light" enableSystem={false}>
+    <NextThemesProvider defaultTheme="light" enableSystem={false} {...props}>
       {children}
     </NextThemesProvider>
   );

--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -9,6 +9,16 @@
  * ============================================================
  */
 
+import type { StaticImageData } from 'next/image';
+
+import digipinImage from '../media/digipin.webp';
+import geonetworkUiImage from '../media/geonetwork-ui.webp';
+import geoserverCloudMcpImage from '../media/geoservercloud-mcp.webp';
+import odoolingsImage from '../media/odoolings.webp';
+import olBenchImage from '../media/olBench.webp';
+import qgisHubImage from '../media/QGIS-Banner.webp';
+import thinkhazardImage from '../media/thinkhazard.webp';
+
 // ---------------------
 // Personal Information
 // ---------------------
@@ -33,6 +43,9 @@ export const siteConfig = {
   greetings: ['Hello!', 1000, 'Hola!', 1000, 'Bonjour!', 1000, 'Namaste!', 1000] as (
     string | number
   )[],
+
+  /** Default color theme on first visit: 'light', 'dark', or 'system' */
+  defaultTheme: 'light' as 'light' | 'dark' | 'system',
 };
 
 // ---------------------
@@ -121,12 +134,8 @@ export interface Project {
   github: string;
   /** Live demo URL */
   live: string;
-  /**
-   * Image filename inside src/media/ (e.g. 'digipin.webp').
-   * You must also add the actual image file to that folder.
-   * The component will import it dynamically.
-   */
-  image: string;
+  /** Thumbnail, imported from src/media/ at the top of this file */
+  image: StaticImageData;
 }
 
 export const projects: Project[] = [
@@ -137,7 +146,7 @@ export const projects: Project[] = [
     tech: ['Python', 'Odoo', 'Next.js', 'Docker', 'PostgreSQL'],
     github: 'https://github.com/ronitjadhav/odoolings',
     live: 'https://odoolings.ronit.io',
-    image: 'odoolings.webp',
+    image: odoolingsImage,
   },
   {
     title: 'GeoServer MCP',
@@ -146,7 +155,7 @@ export const projects: Project[] = [
     tech: ['Python', 'GeoServer', 'MCP', 'FastMCP', 'REST API', 'Docker'],
     github: 'https://github.com/ronitjadhav/geoservercloud-mcp',
     live: 'https://pypi.org/project/geoservercloud-mcp/',
-    image: 'geoservercloud-mcp.webp',
+    image: geoserverCloudMcpImage,
   },
   {
     title: 'Geonetwork-UI',
@@ -155,7 +164,7 @@ export const projects: Project[] = [
     tech: ['Angular', 'TypeScript', 'Tailwind CSS', 'Jest', 'Cypress'],
     github: 'https://github.com/geonetwork/geonetwork-ui',
     live: 'https://geonetwork-ui.labs.camptocamp.com/datahub',
-    image: 'geonetwork-ui.webp',
+    image: geonetworkUiImage,
   },
   {
     title: 'ThinkHazard (World Bank)',
@@ -164,7 +173,7 @@ export const projects: Project[] = [
     tech: ['Python', 'Pyramid', 'GeoPandas', 'Docker', 'Kubernetes'],
     github: 'https://github.com/GFDRR/thinkhazard',
     live: 'https://thinkhazard.org',
-    image: 'thinkhazard.webp',
+    image: thinkhazardImage,
   },
   {
     title: 'QGIS Hub Plugin',
@@ -173,7 +182,7 @@ export const projects: Project[] = [
     tech: ['Python', 'Qt', 'QGIS'],
     github: 'https://github.com/qgis/QGIS-Hub-Plugin',
     live: 'https://plugins.qgis.org/plugins/qgis_hub_plugin/',
-    image: 'QGIS-Banner.webp',
+    image: qgisHubImage,
   },
   {
     title: 'Openlayers Benchmark',
@@ -182,7 +191,7 @@ export const projects: Project[] = [
     tech: ['Openlayers', 'TypeScript'],
     github: 'https://github.com/openlayers/bench',
     live: 'https://openlayers.org/bench/',
-    image: 'olBench.webp',
+    image: olBenchImage,
   },
   {
     title: 'Digipin',
@@ -191,7 +200,7 @@ export const projects: Project[] = [
     tech: ['Openlayers', 'Next.js', 'TypeScript', 'Tailwind CSS'],
     github: 'https://github.com/ronitjadhav/digipin-openlayers',
     live: 'https://digipin.maplabs.tech',
-    image: 'digipin.webp',
+    image: digipinImage,
   },
 ];
 

--- a/src/sections/projects.tsx
+++ b/src/sections/projects.tsx
@@ -1,34 +1,11 @@
 import React from 'react';
 import { ArrowSquareOut } from '@phosphor-icons/react/ssr';
 import { FaGithub } from 'react-icons/fa';
-import digipinImage from '../media/digipin.webp';
-import qgisHubImage from '../media/QGIS-Banner.webp';
-import olBenchImage from '../media/olBench.webp';
-import geonetworkUiImage from '../media/geonetwork-ui.webp';
-import thinkhazardImage from '../media/thinkhazard.webp';
-import geoserverCloudMcpImage from '../media/geoservercloud-mcp.webp';
-import odoolingsImage from '../media/odoolings.webp';
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 import { cn } from '@/lib/utils';
-import { projects as projectsConfig } from '@/data/site-config';
-
-// Map image filenames from config to actual imported images
-const imageMap: Record<string, StaticImageData> = {
-  'digipin.webp': digipinImage,
-  'QGIS-Banner.webp': qgisHubImage,
-  'olBench.webp': olBenchImage,
-  'geonetwork-ui.webp': geonetworkUiImage,
-  'thinkhazard.webp': thinkhazardImage,
-  'geoservercloud-mcp.webp': geoserverCloudMcpImage,
-  'odoolings.webp': odoolingsImage,
-};
+import { projects } from '@/data/site-config';
 
 const ProjectsShowcase = () => {
-  const projects = projectsConfig.map((p) => ({
-    ...p,
-    image: imageMap[p.image] || digipinImage,
-  }));
-
   return (
     <div className="relative w-full py-8 sm:py-12 md:py-16 p-3 sm:p-5 md:p-8 bg-white dark:bg-black">
       {/* Grid background */}


### PR DESCRIPTION
## Summary

`CUSTOMIZATION.md` promised `site-config.ts` was the only file to edit, but adding a project also meant editing `src/sections/projects.tsx` to add an import and an `imageMap` entry. The lookup fell back to `|| digipinImage`, so a missing entry **silently rendered the wrong project's thumbnail** rather than failing — hit for real while adding the Odoolings project.

- Move image imports into `site-config.ts`; type `Project.image` as `StaticImageData` so a bad reference is a build error
- Delete `imageMap`, its 7 imports, and the silent fallback
- Surface theme default as `siteConfig.defaultTheme` (`'light' | 'dark' | 'system'`) instead of hardcoding in `layout.tsx`
- Fix `theme-provider.tsx` spreading `{...props}` *before* its own hardcoded `defaultTheme`/`enableSystem`, which made caller-supplied theme props silently impossible to override
- Update `CUSTOMIZATION.md` to match

Net −14 lines.

Static import is free here: `next.config.ts` already sets `images.unoptimized: true` for the static export, and the component hardcodes `width`/`height`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `npm run build` succeeds
- [x] All 7 project thumbnails verified present in `out/` export

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DikDVkBNpgH6JJnoGXvc3X