### PR TITLE
Fix navbar anchors scrolling to section end instead of start

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,18 @@
   box-sizing: border-box;
 }
 
+/* Keep the sticky navbar from covering a section's start when jumping to its
+   anchor. Matches the navbar's own height (top-4 + margin + h-[60/70/80px]). */
+section[id] {
+  scroll-margin-top: 6rem;
+}
+
+@media (min-width: 768px) {
+  section[id] {
+    scroll-margin-top: 8rem;
+  }
+}
+
 body {
   --sb-track-color: #ffffff;
   --sb-thumb-color: #000000;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { navLinks } from '@/data/site-config';
 
 const scrolltoHash = function (element_id: string) {
   const element = document.getElementById(element_id);
-  element?.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+  element?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
 };
 
 const NavBar = () => {


### PR DESCRIPTION
## Summary

Clicking **Projects** in the navbar landed at the *bottom* of the projects section rather than its heading.

Cause: `scrolltoHash` in `src/components/Navbar.tsx` used `scrollIntoView({ block: 'end' })`, which aligns the element's **bottom** edge with the viewport bottom. On the ~2070px-tall Projects section that means landing on the last row of cards.

- `block: 'end'` → `block: 'start'`
- Add `scroll-margin-top` on `section[id]` (6rem, 8rem at ≥768px) so the sticky navbar doesn't cover the heading it just scrolled to

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified in Chrome against `next dev`: after clicking each navbar link the section top sits at 128px, clear of the navbar
  - Projects: `top: 128` (was landing ~1940px into a 2070px section)
  - Journey: `top: 128`
- [x] Screenshots confirm both land on their headings ("Projects I've Worked On", "My Journey Through Time & Space")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DikDVkBNpgH6JJnoGXvc3X